### PR TITLE
conda: simplify run dependencies

### DIFF
--- a/conda/cmaboss/meta.yaml
+++ b/conda/cmaboss/meta.yaml
@@ -26,21 +26,18 @@ requirements:
     - numpy {{ numpy }}
     - setuptools
     - libsbml-plus-packages
-    - libxml2
     
   host: 
     - python {{ python }}
     - numpy {{ numpy }}
     - setuptools
     - libsbml-plus-packages
-    - libxml2
   
   run: 
     - python {{ python }}
-    - numpy {{ numpy }}
+    - numpy
     - setuptools
     - libsbml-plus-packages
-    - libxml2
 
 about:
   home:  https://maboss.curie.fr

--- a/conda/maboss/meta.yaml
+++ b/conda/maboss/meta.yaml
@@ -24,16 +24,13 @@ requirements:
     - bison
     - make
     - libsbml-plus-packages
-    - libxml2
         
   host:
     - libsbml-plus-packages
-    - libxml2
     
   run:
     - libsbml-plus-packages
-    - libxml2
-      
+
 about:
   home:  https://maboss.curie.fr
 


### PR DESCRIPTION
To be merged after https://github.com/vincent-noel/libsbml-plus-packages/pull/1
Add build variants for libxml2
(probably that keeping libxml2 2.9 is useless)